### PR TITLE
Fix basic usage

### DIFF
--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -127,7 +127,7 @@ class LLMClient:
                 # print(full_content)
                 # Optional: print streaming content in real-time
                 # print(content, end='', flush=True)
-        print(full_content)
+        # print(full_content)
         print()
         return ''.join(full_content)
 


### PR DESCRIPTION
Hi, I am very interested in your work and thank you for open sourcing the code. When I run Basic Usage according to readme.md. The error is reported as shown in the figure 
<img width="1279" height="417" alt="ab4b1843f092fdcf310f090e252b0813" src="https://github.com/user-attachments/assets/4436ba2d-2b5a-4fe3-8195-192af527a3b3" />
After debugging, I found that chunk.choices in llm_client.py may have a value with a length of 0, but there is no judgment in the code, so I added a judgment condition. Now the code can output the answer like in Basic Usage.
<img width="916" height="203" alt="image" src="https://github.com/user-attachments/assets/feba3a1a-6373-43e3-adaa-43e287ff6f0c" />
However, I haven’t seen any contribution specifications. If my code is not written in a standardized way, please let me know. Thank you.