### PR TITLE
fix: avoid numpy truth-value ambiguity in keyword/structured search

### DIFF
--- a/MCP/server/database/vector_store.py
+++ b/MCP/server/database/vector_store.py
@@ -190,7 +190,8 @@ class MultiTenantVectorStore:
             scores = []
             for idx, row in df.iterrows():
                 score = 0
-                entry_keywords = set(k.lower() for k in (row["keywords"] or []))
+                row_keywords = row["keywords"] if row["keywords"] is not None else []
+                entry_keywords = set(k.lower() for k in row_keywords)
                 entry_text = row["lossless_restatement"].lower()
 
                 for kw in keywords:
@@ -267,7 +268,8 @@ class MultiTenantVectorStore:
             if persons:
                 persons_lower = set(p.lower() for p in persons)
                 for i, row in df.iterrows():
-                    row_persons = set(p.lower() for p in (row["persons"] or []))
+                    persons_val = row["persons"] if row["persons"] is not None else []
+                    row_persons = set(p.lower() for p in persons_val)
                     if not persons_lower.intersection(row_persons):
                         mask[i] = False
 
@@ -284,7 +286,8 @@ class MultiTenantVectorStore:
                 entities_lower = set(e.lower() for e in entities)
                 for i, row in df.iterrows():
                     if mask[i]:
-                        row_entities = set(e.lower() for e in (row["entities"] or []))
+                        entities_val = row["entities"] if row["entities"] is not None else []
+                        row_entities = set(e.lower() for e in entities_val)
                         if not entities_lower.intersection(row_entities):
                             mask[i] = False
 


### PR DESCRIPTION
## Summary
- Fixes `Keyword search error: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()` surfaced in server logs during hybrid or structured search.
- Root cause: `row["keywords"] or []` (same pattern for `persons`, `entities`) evaluates `bool(numpy_array)`, since LanceDB's `to_pandas()` returns list columns as numpy arrays.
- Aligns with the `is not None` idiom already used when constructing `MemoryEntry` objects in the same file.

## Test plan
- [x] `memory_add` single insert — no log error
- [x] `memory_add_batch` bulk insert — no log error
- [x] `memory_query` (exercises `keyword_search` over 50+ rows) — no log error
- [x] Parallel queries under concurrent batch writes — zero occurrences of `truth value` / `ambiguous` in `docker logs`