### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 JWT_SECRET_KEY=your-secure-random-secret-key
 ENCRYPTION_KEY=your-32-byte-encryption-key!!
 
-# LLM provider: openrouter | ollama
+# LLM provider: openrouter | requesty | ollama
 LLM_PROVIDER=openrouter
 
 # When using Ollama (e.g. on host): use host.docker.internal so container can reach host
@@ -14,6 +14,10 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
 
 # OpenRouter (when LLM_PROVIDER=openrouter)
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
+# Requesty (when LLM_PROVIDER=requesty) - OpenAI-compatible router
+# Get an API key at https://app.requesty.ai/api-keys - docs: https://docs.requesty.ai
+REQUESTY_BASE_URL=https://router.requesty.ai/v1
 
 # Models
 LLM_MODEL=openai/gpt-4.1-mini

--- a/MCP/config/settings.py
+++ b/MCP/config/settings.py
@@ -64,13 +64,19 @@ class Settings:
     # LLM Provider Configuration
     llm_provider: str = field(default_factory=lambda: os.getenv(
         "LLM_PROVIDER",
-        "openrouter"  # Options: "openrouter", "ollama"
+        "openrouter"  # Options: "openrouter", "requesty", "ollama"
     ))
 
     # OpenRouter Configuration (used when llm_provider is "openrouter")
     openrouter_base_url: str = field(default_factory=lambda: os.getenv(
         "OPENROUTER_BASE_URL",
         "https://openrouter.ai/api/v1"
+    ))
+
+    # Requesty Configuration (used when llm_provider is "requesty")
+    requesty_base_url: str = field(default_factory=lambda: os.getenv(
+        "REQUESTY_BASE_URL",
+        "https://router.requesty.ai/v1"
     ))
 
     # Ollama Configuration (used when llm_provider is "ollama")

--- a/MCP/server/http_server.py
+++ b/MCP/server/http_server.py
@@ -35,6 +35,7 @@ from .auth.models import User
 from .database.user_store import UserStore
 from .database.vector_store import MultiTenantVectorStore
 from .integrations.openrouter import OpenRouterClient, OpenRouterClientManager
+from .integrations.requesty import RequestyClient, RequestyClientManager
 from .integrations.ollama import OllamaClient, OllamaClientManager
 from .mcp_handler import MCPHandler
 
@@ -106,6 +107,12 @@ token_manager = TokenManager(
 if settings.llm_provider == "ollama":
     client_manager = OllamaClientManager(
         base_url=settings.ollama_base_url,
+        llm_model=settings.llm_model,
+        embedding_model=settings.embedding_model,
+    )
+elif settings.llm_provider == "requesty":
+    client_manager = RequestyClientManager(
+        base_url=settings.requesty_base_url,
         llm_model=settings.llm_model,
         embedding_model=settings.embedding_model,
     )
@@ -307,6 +314,20 @@ async def register(request: RegisterRequest):
                 return RegisterResponse(
                     success=False,
                     error=f"Cannot connect to Ollama: {error}",
+                )
+        elif settings.llm_provider == "requesty":
+            # For Requesty, validate the API key
+            client = RequestyClient(
+                api_key=api_key,
+                base_url=settings.requesty_base_url,
+            )
+            is_valid, error = await client.verify_api_key()
+            await client.close()
+
+            if not is_valid:
+                return RegisterResponse(
+                    success=False,
+                    error=f"Invalid Requesty API key: {error}",
                 )
         else:
             # For OpenRouter, validate the API key

--- a/MCP/server/integrations/__init__.py
+++ b/MCP/server/integrations/__init__.py
@@ -1,11 +1,14 @@
 """External integrations for SimpleMem"""
 
 from .openrouter import OpenRouterClient, OpenRouterClientManager
+from .requesty import RequestyClient, RequestyClientManager
 from .ollama import OllamaClient, OllamaClientManager
 
 __all__ = [
     "OpenRouterClient",
     "OpenRouterClientManager",
+    "RequestyClient",
+    "RequestyClientManager",
     "OllamaClient",
     "OllamaClientManager",
 ]

--- a/MCP/server/integrations/requesty.py
+++ b/MCP/server/integrations/requesty.py
@@ -1,0 +1,359 @@
+"""
+Requesty SDK integration for LLM and Embedding services
+"""
+
+import json
+import re
+from typing import List, Dict, Any, Optional, AsyncGenerator
+
+
+class RequestyClient:
+    """
+    Requesty API client for LLM and Embedding operations.
+    Each instance is bound to a specific user's API key.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+    ):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+
+        # Lazy import to avoid issues if not installed
+        self._client = None
+
+    def _get_client(self):
+        """Get or create the HTTP client"""
+        if self._client is None:
+            import httpx
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    "HTTP-Referer": "https://simplemem.app",
+                    "X-Title": "SimpleMem MCP Server",
+                },
+                timeout=120.0,
+            )
+        return self._client
+
+    async def close(self):
+        """Close the HTTP client"""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.1,
+        max_tokens: Optional[int] = None,
+        response_format: Optional[Dict] = None,
+        stream: bool = False,
+    ) -> str:
+        """
+        Call LLM for chat completion
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            temperature: Sampling temperature (0-2)
+            max_tokens: Maximum tokens in response
+            response_format: Optional response format (e.g., {"type": "json_object"})
+            stream: Whether to stream the response
+
+        Returns:
+            Generated text content
+        """
+        client = self._get_client()
+
+        payload = {
+            "model": self.llm_model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if max_tokens:
+            payload["max_tokens"] = max_tokens
+
+        if response_format:
+            payload["response_format"] = response_format
+
+        if stream:
+            return await self._stream_completion(payload)
+
+        response = await client.post("/chat/completions", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        return data["choices"][0]["message"]["content"]
+
+    async def _stream_completion(self, payload: Dict) -> str:
+        """Stream chat completion and return full content"""
+        client = self._get_client()
+        payload["stream"] = True
+
+        content_parts = []
+
+        async with client.stream("POST", "/chat/completions", json=payload) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    if data_str.strip() == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(data_str)
+                        delta = data["choices"][0].get("delta", {})
+                        if "content" in delta:
+                            content_parts.append(delta["content"])
+                    except json.JSONDecodeError:
+                        continue
+
+        return "".join(content_parts)
+
+    async def create_embedding(
+        self,
+        texts: List[str],
+    ) -> List[List[float]]:
+        """
+        Create embeddings for texts
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of embedding vectors
+        """
+        client = self._get_client()
+
+        payload = {
+            "model": self.embedding_model,
+            "input": texts,
+        }
+
+        response = await client.post("/embeddings", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        # Sort by index to ensure correct order
+        embeddings_data = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in embeddings_data]
+
+    async def create_single_embedding(self, text: str) -> List[float]:
+        """Create embedding for a single text"""
+        embeddings = await self.create_embedding([text])
+        return embeddings[0]
+
+    async def verify_api_key(self) -> tuple[bool, Optional[str]]:
+        """
+        Verify that the API key is a valid Requesty key
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        if not self.api_key:
+            return False, "Missing API key. Get yours at app.requesty.ai/api-keys"
+
+        try:
+            client = self._get_client()
+            # Use /models endpoint to verify the key
+            response = await client.get("/models")
+            if response.status_code == 200:
+                return True, None
+            elif response.status_code == 401:
+                return False, "Invalid or expired API key"
+            elif response.status_code == 403:
+                return False, "API key access denied"
+            else:
+                return False, f"API error: {response.status_code}"
+        except Exception as e:
+            return False, f"Connection error: {str(e)}"
+
+    def extract_json(self, text: str) -> Any:
+        """
+        Extract JSON from LLM response text with robust parsing
+
+        Args:
+            text: Raw text that may contain JSON
+
+        Returns:
+            Parsed JSON object
+        """
+        if not text:
+            return None
+
+        # Strategy 1: Direct JSON parsing
+        try:
+            return json.loads(text.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # Strategy 2: Extract from ```json ``` blocks
+        json_block_pattern = r"```json\s*([\s\S]*?)\s*```"
+        matches = re.findall(json_block_pattern, text, re.IGNORECASE)
+        if matches:
+            try:
+                return json.loads(matches[0].strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 3: Extract from generic ``` ``` blocks
+        generic_block_pattern = r"```\s*([\s\S]*?)\s*```"
+        matches = re.findall(generic_block_pattern, text)
+        if matches:
+            for match in matches:
+                try:
+                    return json.loads(match.strip())
+                except json.JSONDecodeError:
+                    continue
+
+        # Strategy 4: Find balanced JSON object/array
+        # Find first { or [
+        start_obj = text.find("{")
+        start_arr = text.find("[")
+
+        if start_obj == -1 and start_arr == -1:
+            return None
+
+        if start_arr == -1 or (start_obj != -1 and start_obj < start_arr):
+            # Try to find matching }
+            json_str = self._extract_balanced_braces(text[start_obj:], "{", "}")
+        else:
+            # Try to find matching ]
+            json_str = self._extract_balanced_braces(text[start_arr:], "[", "]")
+
+        if json_str:
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 5: Clean and retry
+        cleaned = self._clean_json_string(text)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            pass
+
+        return None
+
+    def _extract_balanced_braces(self, text: str, open_char: str, close_char: str) -> Optional[str]:
+        """Extract a balanced brace-enclosed string"""
+        if not text or text[0] != open_char:
+            return None
+
+        count = 0
+        in_string = False
+        escape_next = False
+
+        for i, char in enumerate(text):
+            if escape_next:
+                escape_next = False
+                continue
+
+            if char == "\\":
+                escape_next = True
+                continue
+
+            if char == '"' and not escape_next:
+                in_string = not in_string
+                continue
+
+            if in_string:
+                continue
+
+            if char == open_char:
+                count += 1
+            elif char == close_char:
+                count -= 1
+                if count == 0:
+                    return text[: i + 1]
+
+        return None
+
+    def _clean_json_string(self, text: str) -> str:
+        """Clean common JSON issues from LLM output"""
+        # Remove common prefixes
+        prefixes = [
+            "Here's the JSON:",
+            "Here is the JSON:",
+            "JSON output:",
+            "Output:",
+            "Result:",
+        ]
+        cleaned = text.strip()
+        for prefix in prefixes:
+            if cleaned.lower().startswith(prefix.lower()):
+                cleaned = cleaned[len(prefix):].strip()
+
+        # Remove trailing commas before } or ]
+        cleaned = re.sub(r",\s*([\}\]])", r"\1", cleaned)
+
+        # Remove single-line comments
+        cleaned = re.sub(r"//.*$", "", cleaned, flags=re.MULTILINE)
+
+        return cleaned
+
+
+class RequestyClientManager:
+    """
+    Manages Requesty client instances for multiple users.
+    Provides client pooling and lifecycle management.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+    ):
+        self.base_url = base_url
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+        self._clients: Dict[str, RequestyClient] = {}
+
+    def get_client(self, api_key: str) -> RequestyClient:
+        """
+        Get or create a Requesty client for the given API key
+
+        Args:
+            api_key: User's Requesty API key
+
+        Returns:
+            RequestyClient instance
+        """
+        # Use hash of API key as cache key for security
+        import hashlib
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+        if key_hash not in self._clients:
+            self._clients[key_hash] = RequestyClient(
+                api_key=api_key,
+                base_url=self.base_url,
+                llm_model=self.llm_model,
+                embedding_model=self.embedding_model,
+            )
+
+        return self._clients[key_hash]
+
+    async def close_all(self):
+        """Close all client connections"""
+        for client in self._clients.values():
+            await client.close()
+        self._clients.clear()
+
+    async def remove_client(self, api_key: str):
+        """Remove and close a specific client"""
+        import hashlib
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+        if key_hash in self._clients:
+            await self._clients[key_hash].close()
+            del self._clients[key_hash]

--- a/MCP/server/mcp_handler.py
+++ b/MCP/server/mcp_handler.py
@@ -15,8 +15,8 @@ from .core.memory_builder import MemoryBuilder
 from .core.retriever import Retriever
 from .core.answer_generator import AnswerGenerator
 
-# Type alias for client manager (supports both OpenRouter and Ollama)
-ClientManager = object  # Duck-typed: can be OpenRouterClientManager or OllamaClientManager
+# Type alias for client manager (supports OpenRouter, Requesty, and Ollama)
+ClientManager = object  # Duck-typed: can be OpenRouterClientManager, RequestyClientManager, or OllamaClientManager
 
 
 @dataclass

--- a/README.md
+++ b/README.md
@@ -422,6 +422,17 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
 
 On Linux, `host.docker.internal` is enabled automatically via the Compose file.
 
+### Using Requesty
+
+[Requesty](https://requesty.ai) is an OpenAI-compatible router. To use it, set in `.env`:
+
+```bash
+LLM_PROVIDER=requesty
+REQUESTY_BASE_URL=https://router.requesty.ai/v1
+```
+
+Provide your Requesty API key (from [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)) when registering. Models use the same `provider/model` naming as OpenRouter (e.g. `openai/gpt-4.1-mini`). See the [Requesty docs](https://docs.requesty.ai) for available models.
+
 ### Useful commands
 
 ```bash

--- a/SKILL/README.md
+++ b/SKILL/README.md
@@ -68,6 +68,7 @@ Supported models (configurable):
 
 - **Main Guide**: `simplemem-skill/SKILL.md`
 - **OpenRouter Setup**: `simplemem-skill/references/openrouter-guide.md`
+- **Requesty Setup**: `simplemem-skill/references/requesty-guide.md`
 - **Import Guide**: `simplemem-skill/references/import-guide.md`
 - **CLI Reference**: `simplemem-skill/references/cli-reference.md`
 - **Architecture Details**: `simplemem-skill/references/architecture.md`

--- a/SKILL/simplemem-skill/references/requesty-guide.md
+++ b/SKILL/simplemem-skill/references/requesty-guide.md
@@ -1,0 +1,75 @@
+# Requesty Integration - Quick Reference
+
+## Why Requesty?
+
+[Requesty](https://requesty.ai) is an OpenAI-compatible router that SimpleMem can use as a unified API gateway for LLM and embedding operations:
+
+- **Single API Key**: One key for all models
+- **Cost Tracking**: Built-in dashboard to monitor usage and costs
+- **Model Flexibility**: Easy to switch between providers and models
+- **Simpler Setup**: No need to manage multiple API keys
+
+## Getting Started
+
+### 1. Get Your API Key
+
+Visit [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys) and create an account to generate an API key.
+
+### 2. Configure the Skill
+
+```bash
+cd SKILL/simplemem-skill
+cp src/config.py.example src/config.py
+```
+
+Edit `src/config.py` to point the OpenAI-compatible base URL at Requesty and set your key:
+
+```python
+OPENROUTER_BASE_URL = "https://router.requesty.ai/v1"
+OPENROUTER_API_KEY = "your-requesty-key"
+```
+
+### 3. Choose Your Models
+
+Edit `src/config.py` to select models (Requesty uses the same `provider/model` naming as OpenRouter):
+
+```python
+# LLM Model (for chat/reasoning)
+LLM_MODEL = "openai/gpt-4.1-mini"
+
+# Embedding Model (for vector search)
+EMBEDDING_MODEL = "openai/text-embedding-3-small"
+
+# Embedding dimension (must match the embedding model)
+EMBEDDING_DIMENSION = 1536
+```
+
+**Important**: The `EMBEDDING_DIMENSION` must match your chosen embedding model. Check the model documentation in the [Requesty docs](https://docs.requesty.ai).
+
+## Cost Management
+
+Track your usage on the [Requesty dashboard](https://app.requesty.ai).
+
+## Troubleshooting
+
+**"Invalid or expired API key" error**:
+- Get a new key from [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)
+
+**"Model not found" error**:
+- Check the model name in the [Requesty docs](https://docs.requesty.ai)
+- Ensure you're using the full path (e.g., `openai/gpt-4.1-mini`, not just `gpt-4.1-mini`)
+
+**Embedding dimension mismatch error**:
+```
+RuntimeError: lance error: LanceError(Arrow): Arrow error: C Data interface error:
+Invalid: ListType can only be casted to FixedSizeListType if the lists are all
+the expected size.
+```
+- This means `EMBEDDING_DIMENSION` doesn't match your embedding model
+- Check your model's actual dimension in the Requesty docs and update `EMBEDDING_DIMENSION`
+- If you change the embedding dimension, clear the old database: `rm -rf data/lancedb/*`
+
+**"Connection error" or timeout**:
+- Check your internet connection
+- The Requesty router may be experiencing downtime
+- Try again after a few minutes

--- a/SKILL/simplemem-skill/src/utils/requesty.py
+++ b/SKILL/simplemem-skill/src/utils/requesty.py
@@ -1,0 +1,239 @@
+"""
+Requesty Client - Unified interface for LLM and Embedding via Requesty API
+Supports both synchronous and async operations
+"""
+
+import json
+import re
+from typing import List, Dict, Any, Optional
+
+
+class RequestyClient:
+    """
+    Synchronous Requesty API client for LLM and Embedding operations.
+    Simpler and more direct than the MCP async version.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+        app_name: str = "SimpleMem Skill",
+    ):
+        """
+        Initialize Requesty client
+
+        Args:
+            api_key: Requesty API key
+            base_url: Requesty API base URL
+            llm_model: Model for chat completions
+            embedding_model: Model for embeddings
+            app_name: Application name for tracking
+        """
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+        self.app_name = app_name
+
+        # Use requests for synchronous HTTP calls
+        import requests
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "http://simplemem.cloud",
+            "X-Title": self.app_name,
+        })
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.1,
+        max_tokens: Optional[int] = None,
+        response_format: Optional[Dict] = None,
+    ) -> str:
+        """
+        Call LLM for chat completion
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            temperature: Sampling temperature (0-2)
+            max_tokens: Maximum tokens in response
+            response_format: Optional response format (e.g., {"type": "json_object"})
+
+        Returns:
+            Generated text content
+        """
+        payload = {
+            "model": self.llm_model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if max_tokens:
+            payload["max_tokens"] = max_tokens
+
+        if response_format:
+            payload["response_format"] = response_format
+
+        url = f"{self.base_url}/chat/completions"
+        response = self.session.post(url, json=payload, timeout=120)
+        response.raise_for_status()
+        data = response.json()
+
+        return data["choices"][0]["message"]["content"]
+
+    def create_embedding(
+        self,
+        texts: List[str],
+    ) -> List[List[float]]:
+        """
+        Create embeddings for texts
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of embedding vectors
+        """
+        payload = {
+            "model": self.embedding_model,
+            "input": texts,
+        }
+
+        url = f"{self.base_url}/embeddings"
+        response = self.session.post(url, json=payload, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+        # Sort by index to ensure correct order
+        embeddings_data = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in embeddings_data]
+
+    def create_single_embedding(self, text: str) -> List[float]:
+        """Create embedding for a single text"""
+        embeddings = self.create_embedding([text])
+        return embeddings[0]
+
+    def verify_api_key(self) -> tuple[bool, Optional[str]]:
+        """
+        Verify that the API key is valid
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        if not self.api_key:
+            return False, "Missing API key. Get yours at app.requesty.ai/api-keys"
+
+        try:
+            url = f"{self.base_url}/models"
+            response = self.session.get(url, timeout=10)
+
+            if response.status_code == 200:
+                return True, None
+            elif response.status_code == 401:
+                return False, "Invalid or expired API key"
+            elif response.status_code == 403:
+                return False, "API key access denied"
+            else:
+                return False, f"API error: {response.status_code}"
+        except Exception as e:
+            return False, f"Connection error: {str(e)}"
+
+    def extract_json(self, text: str) -> Any:
+        """
+        Extract JSON from LLM response text with robust parsing
+
+        Args:
+            text: Raw text that may contain JSON
+
+        Returns:
+            Parsed JSON object
+        """
+        if not text:
+            return None
+
+        # Strategy 1: Direct JSON parsing
+        try:
+            return json.loads(text.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # Strategy 2: Extract from ```json ``` blocks
+        json_block_pattern = r"```json\s*([\s\S]*?)\s*```"
+        matches = re.findall(json_block_pattern, text, re.IGNORECASE)
+        if matches:
+            try:
+                return json.loads(matches[0].strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 3: Extract from generic ``` ``` blocks
+        generic_block_pattern = r"```\s*([\s\S]*?)\s*```"
+        matches = re.findall(generic_block_pattern, text)
+        if matches:
+            for match in matches:
+                try:
+                    return json.loads(match.strip())
+                except json.JSONDecodeError:
+                    continue
+
+        # Strategy 4: Find balanced JSON object/array
+        start_obj = text.find("{")
+        start_arr = text.find("[")
+
+        if start_obj == -1 and start_arr == -1:
+            return None
+
+        if start_arr == -1 or (start_obj != -1 and start_obj < start_arr):
+            json_str = self._extract_balanced_braces(text[start_obj:], "{", "}")
+        else:
+            json_str = self._extract_balanced_braces(text[start_arr:], "[", "]")
+
+        if json_str:
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
+    def _extract_balanced_braces(self, text: str, open_char: str, close_char: str) -> Optional[str]:
+        """Extract balanced braces/brackets from text"""
+        if not text or text[0] != open_char:
+            return None
+
+        depth = 0
+        in_string = False
+        escape = False
+
+        for i, char in enumerate(text):
+            if escape:
+                escape = False
+                continue
+
+            if char == "\\":
+                escape = True
+                continue
+
+            if char == '"' and not in_string:
+                in_string = True
+            elif char == '"' and in_string:
+                in_string = False
+
+            if not in_string:
+                if char == open_char:
+                    depth += 1
+                elif char == close_char:
+                    depth -= 1
+                    if depth == 0:
+                        return text[:i+1]
+
+        return None
+
+    def close(self):
+        """Close the HTTP session"""
+        self.session.close()

--- a/simplemem/integrations/README.md
+++ b/simplemem/integrations/README.md
@@ -68,6 +68,7 @@ Supported models (configurable):
 
 - **Main Guide**: `simplemem-skill/SKILL.md`
 - **OpenRouter Setup**: `simplemem-skill/references/openrouter-guide.md`
+- **Requesty Setup**: `simplemem-skill/references/requesty-guide.md`
 - **Import Guide**: `simplemem-skill/references/import-guide.md`
 - **CLI Reference**: `simplemem-skill/references/cli-reference.md`
 - **Architecture Details**: `simplemem-skill/references/architecture.md`

--- a/simplemem/integrations/config/settings.py
+++ b/simplemem/integrations/config/settings.py
@@ -64,13 +64,19 @@ class Settings:
     # LLM Provider Configuration
     llm_provider: str = field(default_factory=lambda: os.getenv(
         "LLM_PROVIDER",
-        "openrouter"  # Options: "openrouter", "ollama"
+        "openrouter"  # Options: "openrouter", "requesty", "ollama"
     ))
 
     # OpenRouter Configuration (used when llm_provider is "openrouter")
     openrouter_base_url: str = field(default_factory=lambda: os.getenv(
         "OPENROUTER_BASE_URL",
         "https://openrouter.ai/api/v1"
+    ))
+
+    # Requesty Configuration (used when llm_provider is "requesty")
+    requesty_base_url: str = field(default_factory=lambda: os.getenv(
+        "REQUESTY_BASE_URL",
+        "https://router.requesty.ai/v1"
     ))
 
     # Ollama Configuration (used when llm_provider is "ollama")

--- a/simplemem/integrations/server/http_server.py
+++ b/simplemem/integrations/server/http_server.py
@@ -35,6 +35,7 @@ from .auth.models import User
 from .database.user_store import UserStore
 from .database.vector_store import MultiTenantVectorStore
 from .integrations.openrouter import OpenRouterClient, OpenRouterClientManager
+from .integrations.requesty import RequestyClient, RequestyClientManager
 from .integrations.ollama import OllamaClient, OllamaClientManager
 from .mcp_handler import MCPHandler
 
@@ -106,6 +107,12 @@ token_manager = TokenManager(
 if settings.llm_provider == "ollama":
     client_manager = OllamaClientManager(
         base_url=settings.ollama_base_url,
+        llm_model=settings.llm_model,
+        embedding_model=settings.embedding_model,
+    )
+elif settings.llm_provider == "requesty":
+    client_manager = RequestyClientManager(
+        base_url=settings.requesty_base_url,
         llm_model=settings.llm_model,
         embedding_model=settings.embedding_model,
     )
@@ -307,6 +314,20 @@ async def register(request: RegisterRequest):
                 return RegisterResponse(
                     success=False,
                     error=f"Cannot connect to Ollama: {error}",
+                )
+        elif settings.llm_provider == "requesty":
+            # For Requesty, validate the API key
+            client = RequestyClient(
+                api_key=api_key,
+                base_url=settings.requesty_base_url,
+            )
+            is_valid, error = await client.verify_api_key()
+            await client.close()
+
+            if not is_valid:
+                return RegisterResponse(
+                    success=False,
+                    error=f"Invalid Requesty API key: {error}",
                 )
         else:
             # For OpenRouter, validate the API key

--- a/simplemem/integrations/server/integrations/__init__.py
+++ b/simplemem/integrations/server/integrations/__init__.py
@@ -1,11 +1,14 @@
 """External integrations for SimpleMem"""
 
 from .openrouter import OpenRouterClient, OpenRouterClientManager
+from .requesty import RequestyClient, RequestyClientManager
 from .ollama import OllamaClient, OllamaClientManager
 
 __all__ = [
     "OpenRouterClient",
     "OpenRouterClientManager",
+    "RequestyClient",
+    "RequestyClientManager",
     "OllamaClient",
     "OllamaClientManager",
 ]

--- a/simplemem/integrations/server/integrations/requesty.py
+++ b/simplemem/integrations/server/integrations/requesty.py
@@ -1,0 +1,359 @@
+"""
+Requesty SDK integration for LLM and Embedding services
+"""
+
+import json
+import re
+from typing import List, Dict, Any, Optional, AsyncGenerator
+
+
+class RequestyClient:
+    """
+    Requesty API client for LLM and Embedding operations.
+    Each instance is bound to a specific user's API key.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+    ):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+
+        # Lazy import to avoid issues if not installed
+        self._client = None
+
+    def _get_client(self):
+        """Get or create the HTTP client"""
+        if self._client is None:
+            import httpx
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    "HTTP-Referer": "https://simplemem.app",
+                    "X-Title": "SimpleMem MCP Server",
+                },
+                timeout=120.0,
+            )
+        return self._client
+
+    async def close(self):
+        """Close the HTTP client"""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.1,
+        max_tokens: Optional[int] = None,
+        response_format: Optional[Dict] = None,
+        stream: bool = False,
+    ) -> str:
+        """
+        Call LLM for chat completion
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            temperature: Sampling temperature (0-2)
+            max_tokens: Maximum tokens in response
+            response_format: Optional response format (e.g., {"type": "json_object"})
+            stream: Whether to stream the response
+
+        Returns:
+            Generated text content
+        """
+        client = self._get_client()
+
+        payload = {
+            "model": self.llm_model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if max_tokens:
+            payload["max_tokens"] = max_tokens
+
+        if response_format:
+            payload["response_format"] = response_format
+
+        if stream:
+            return await self._stream_completion(payload)
+
+        response = await client.post("/chat/completions", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        return data["choices"][0]["message"]["content"]
+
+    async def _stream_completion(self, payload: Dict) -> str:
+        """Stream chat completion and return full content"""
+        client = self._get_client()
+        payload["stream"] = True
+
+        content_parts = []
+
+        async with client.stream("POST", "/chat/completions", json=payload) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    if data_str.strip() == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(data_str)
+                        delta = data["choices"][0].get("delta", {})
+                        if "content" in delta:
+                            content_parts.append(delta["content"])
+                    except json.JSONDecodeError:
+                        continue
+
+        return "".join(content_parts)
+
+    async def create_embedding(
+        self,
+        texts: List[str],
+    ) -> List[List[float]]:
+        """
+        Create embeddings for texts
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of embedding vectors
+        """
+        client = self._get_client()
+
+        payload = {
+            "model": self.embedding_model,
+            "input": texts,
+        }
+
+        response = await client.post("/embeddings", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        # Sort by index to ensure correct order
+        embeddings_data = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in embeddings_data]
+
+    async def create_single_embedding(self, text: str) -> List[float]:
+        """Create embedding for a single text"""
+        embeddings = await self.create_embedding([text])
+        return embeddings[0]
+
+    async def verify_api_key(self) -> tuple[bool, Optional[str]]:
+        """
+        Verify that the API key is a valid Requesty key
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        if not self.api_key:
+            return False, "Missing API key. Get yours at app.requesty.ai/api-keys"
+
+        try:
+            client = self._get_client()
+            # Use /models endpoint to verify the key
+            response = await client.get("/models")
+            if response.status_code == 200:
+                return True, None
+            elif response.status_code == 401:
+                return False, "Invalid or expired API key"
+            elif response.status_code == 403:
+                return False, "API key access denied"
+            else:
+                return False, f"API error: {response.status_code}"
+        except Exception as e:
+            return False, f"Connection error: {str(e)}"
+
+    def extract_json(self, text: str) -> Any:
+        """
+        Extract JSON from LLM response text with robust parsing
+
+        Args:
+            text: Raw text that may contain JSON
+
+        Returns:
+            Parsed JSON object
+        """
+        if not text:
+            return None
+
+        # Strategy 1: Direct JSON parsing
+        try:
+            return json.loads(text.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # Strategy 2: Extract from ```json ``` blocks
+        json_block_pattern = r"```json\s*([\s\S]*?)\s*```"
+        matches = re.findall(json_block_pattern, text, re.IGNORECASE)
+        if matches:
+            try:
+                return json.loads(matches[0].strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 3: Extract from generic ``` ``` blocks
+        generic_block_pattern = r"```\s*([\s\S]*?)\s*```"
+        matches = re.findall(generic_block_pattern, text)
+        if matches:
+            for match in matches:
+                try:
+                    return json.loads(match.strip())
+                except json.JSONDecodeError:
+                    continue
+
+        # Strategy 4: Find balanced JSON object/array
+        # Find first { or [
+        start_obj = text.find("{")
+        start_arr = text.find("[")
+
+        if start_obj == -1 and start_arr == -1:
+            return None
+
+        if start_arr == -1 or (start_obj != -1 and start_obj < start_arr):
+            # Try to find matching }
+            json_str = self._extract_balanced_braces(text[start_obj:], "{", "}")
+        else:
+            # Try to find matching ]
+            json_str = self._extract_balanced_braces(text[start_arr:], "[", "]")
+
+        if json_str:
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 5: Clean and retry
+        cleaned = self._clean_json_string(text)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            pass
+
+        return None
+
+    def _extract_balanced_braces(self, text: str, open_char: str, close_char: str) -> Optional[str]:
+        """Extract a balanced brace-enclosed string"""
+        if not text or text[0] != open_char:
+            return None
+
+        count = 0
+        in_string = False
+        escape_next = False
+
+        for i, char in enumerate(text):
+            if escape_next:
+                escape_next = False
+                continue
+
+            if char == "\\":
+                escape_next = True
+                continue
+
+            if char == '"' and not escape_next:
+                in_string = not in_string
+                continue
+
+            if in_string:
+                continue
+
+            if char == open_char:
+                count += 1
+            elif char == close_char:
+                count -= 1
+                if count == 0:
+                    return text[: i + 1]
+
+        return None
+
+    def _clean_json_string(self, text: str) -> str:
+        """Clean common JSON issues from LLM output"""
+        # Remove common prefixes
+        prefixes = [
+            "Here's the JSON:",
+            "Here is the JSON:",
+            "JSON output:",
+            "Output:",
+            "Result:",
+        ]
+        cleaned = text.strip()
+        for prefix in prefixes:
+            if cleaned.lower().startswith(prefix.lower()):
+                cleaned = cleaned[len(prefix):].strip()
+
+        # Remove trailing commas before } or ]
+        cleaned = re.sub(r",\s*([\}\]])", r"\1", cleaned)
+
+        # Remove single-line comments
+        cleaned = re.sub(r"//.*$", "", cleaned, flags=re.MULTILINE)
+
+        return cleaned
+
+
+class RequestyClientManager:
+    """
+    Manages Requesty client instances for multiple users.
+    Provides client pooling and lifecycle management.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+    ):
+        self.base_url = base_url
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+        self._clients: Dict[str, RequestyClient] = {}
+
+    def get_client(self, api_key: str) -> RequestyClient:
+        """
+        Get or create a Requesty client for the given API key
+
+        Args:
+            api_key: User's Requesty API key
+
+        Returns:
+            RequestyClient instance
+        """
+        # Use hash of API key as cache key for security
+        import hashlib
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+        if key_hash not in self._clients:
+            self._clients[key_hash] = RequestyClient(
+                api_key=api_key,
+                base_url=self.base_url,
+                llm_model=self.llm_model,
+                embedding_model=self.embedding_model,
+            )
+
+        return self._clients[key_hash]
+
+    async def close_all(self):
+        """Close all client connections"""
+        for client in self._clients.values():
+            await client.close()
+        self._clients.clear()
+
+    async def remove_client(self, api_key: str):
+        """Remove and close a specific client"""
+        import hashlib
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+        if key_hash in self._clients:
+            await self._clients[key_hash].close()
+            del self._clients[key_hash]

--- a/simplemem/integrations/server/mcp_handler.py
+++ b/simplemem/integrations/server/mcp_handler.py
@@ -15,8 +15,8 @@ from .core.memory_builder import MemoryBuilder
 from .core.retriever import Retriever
 from .core.answer_generator import AnswerGenerator
 
-# Type alias for client manager (supports both OpenRouter and Ollama)
-ClientManager = object  # Duck-typed: can be OpenRouterClientManager or OllamaClientManager
+# Type alias for client manager (supports OpenRouter, Requesty, and Ollama)
+ClientManager = object  # Duck-typed: can be OpenRouterClientManager, RequestyClientManager, or OllamaClientManager
 
 
 @dataclass

--- a/simplemem/integrations/simplemem-skill/references/requesty-guide.md
+++ b/simplemem/integrations/simplemem-skill/references/requesty-guide.md
@@ -1,0 +1,75 @@
+# Requesty Integration - Quick Reference
+
+## Why Requesty?
+
+[Requesty](https://requesty.ai) is an OpenAI-compatible router that SimpleMem can use as a unified API gateway for LLM and embedding operations:
+
+- **Single API Key**: One key for all models
+- **Cost Tracking**: Built-in dashboard to monitor usage and costs
+- **Model Flexibility**: Easy to switch between providers and models
+- **Simpler Setup**: No need to manage multiple API keys
+
+## Getting Started
+
+### 1. Get Your API Key
+
+Visit [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys) and create an account to generate an API key.
+
+### 2. Configure the Skill
+
+```bash
+cd SKILL/simplemem-skill
+cp src/config.py.example src/config.py
+```
+
+Edit `src/config.py` to point the OpenAI-compatible base URL at Requesty and set your key:
+
+```python
+OPENROUTER_BASE_URL = "https://router.requesty.ai/v1"
+OPENROUTER_API_KEY = "your-requesty-key"
+```
+
+### 3. Choose Your Models
+
+Edit `src/config.py` to select models (Requesty uses the same `provider/model` naming as OpenRouter):
+
+```python
+# LLM Model (for chat/reasoning)
+LLM_MODEL = "openai/gpt-4.1-mini"
+
+# Embedding Model (for vector search)
+EMBEDDING_MODEL = "openai/text-embedding-3-small"
+
+# Embedding dimension (must match the embedding model)
+EMBEDDING_DIMENSION = 1536
+```
+
+**Important**: The `EMBEDDING_DIMENSION` must match your chosen embedding model. Check the model documentation in the [Requesty docs](https://docs.requesty.ai).
+
+## Cost Management
+
+Track your usage on the [Requesty dashboard](https://app.requesty.ai).
+
+## Troubleshooting
+
+**"Invalid or expired API key" error**:
+- Get a new key from [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)
+
+**"Model not found" error**:
+- Check the model name in the [Requesty docs](https://docs.requesty.ai)
+- Ensure you're using the full path (e.g., `openai/gpt-4.1-mini`, not just `gpt-4.1-mini`)
+
+**Embedding dimension mismatch error**:
+```
+RuntimeError: lance error: LanceError(Arrow): Arrow error: C Data interface error:
+Invalid: ListType can only be casted to FixedSizeListType if the lists are all
+the expected size.
+```
+- This means `EMBEDDING_DIMENSION` doesn't match your embedding model
+- Check your model's actual dimension in the Requesty docs and update `EMBEDDING_DIMENSION`
+- If you change the embedding dimension, clear the old database: `rm -rf data/lancedb/*`
+
+**"Connection error" or timeout**:
+- Check your internet connection
+- The Requesty router may be experiencing downtime
+- Try again after a few minutes

--- a/simplemem/integrations/simplemem-skill/src/utils/requesty.py
+++ b/simplemem/integrations/simplemem-skill/src/utils/requesty.py
@@ -1,0 +1,239 @@
+"""
+Requesty Client - Unified interface for LLM and Embedding via Requesty API
+Supports both synchronous and async operations
+"""
+
+import json
+import re
+from typing import List, Dict, Any, Optional
+
+
+class RequestyClient:
+    """
+    Synchronous Requesty API client for LLM and Embedding operations.
+    Simpler and more direct than the MCP async version.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://router.requesty.ai/v1",
+        llm_model: str = "openai/gpt-4.1-mini",
+        embedding_model: str = "openai/text-embedding-3-small",
+        app_name: str = "SimpleMem Skill",
+    ):
+        """
+        Initialize Requesty client
+
+        Args:
+            api_key: Requesty API key
+            base_url: Requesty API base URL
+            llm_model: Model for chat completions
+            embedding_model: Model for embeddings
+            app_name: Application name for tracking
+        """
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.llm_model = llm_model
+        self.embedding_model = embedding_model
+        self.app_name = app_name
+
+        # Use requests for synchronous HTTP calls
+        import requests
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "http://simplemem.cloud",
+            "X-Title": self.app_name,
+        })
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.1,
+        max_tokens: Optional[int] = None,
+        response_format: Optional[Dict] = None,
+    ) -> str:
+        """
+        Call LLM for chat completion
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            temperature: Sampling temperature (0-2)
+            max_tokens: Maximum tokens in response
+            response_format: Optional response format (e.g., {"type": "json_object"})
+
+        Returns:
+            Generated text content
+        """
+        payload = {
+            "model": self.llm_model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if max_tokens:
+            payload["max_tokens"] = max_tokens
+
+        if response_format:
+            payload["response_format"] = response_format
+
+        url = f"{self.base_url}/chat/completions"
+        response = self.session.post(url, json=payload, timeout=120)
+        response.raise_for_status()
+        data = response.json()
+
+        return data["choices"][0]["message"]["content"]
+
+    def create_embedding(
+        self,
+        texts: List[str],
+    ) -> List[List[float]]:
+        """
+        Create embeddings for texts
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of embedding vectors
+        """
+        payload = {
+            "model": self.embedding_model,
+            "input": texts,
+        }
+
+        url = f"{self.base_url}/embeddings"
+        response = self.session.post(url, json=payload, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+        # Sort by index to ensure correct order
+        embeddings_data = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in embeddings_data]
+
+    def create_single_embedding(self, text: str) -> List[float]:
+        """Create embedding for a single text"""
+        embeddings = self.create_embedding([text])
+        return embeddings[0]
+
+    def verify_api_key(self) -> tuple[bool, Optional[str]]:
+        """
+        Verify that the API key is valid
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        if not self.api_key:
+            return False, "Missing API key. Get yours at app.requesty.ai/api-keys"
+
+        try:
+            url = f"{self.base_url}/models"
+            response = self.session.get(url, timeout=10)
+
+            if response.status_code == 200:
+                return True, None
+            elif response.status_code == 401:
+                return False, "Invalid or expired API key"
+            elif response.status_code == 403:
+                return False, "API key access denied"
+            else:
+                return False, f"API error: {response.status_code}"
+        except Exception as e:
+            return False, f"Connection error: {str(e)}"
+
+    def extract_json(self, text: str) -> Any:
+        """
+        Extract JSON from LLM response text with robust parsing
+
+        Args:
+            text: Raw text that may contain JSON
+
+        Returns:
+            Parsed JSON object
+        """
+        if not text:
+            return None
+
+        # Strategy 1: Direct JSON parsing
+        try:
+            return json.loads(text.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # Strategy 2: Extract from ```json ``` blocks
+        json_block_pattern = r"```json\s*([\s\S]*?)\s*```"
+        matches = re.findall(json_block_pattern, text, re.IGNORECASE)
+        if matches:
+            try:
+                return json.loads(matches[0].strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Strategy 3: Extract from generic ``` ``` blocks
+        generic_block_pattern = r"```\s*([\s\S]*?)\s*```"
+        matches = re.findall(generic_block_pattern, text)
+        if matches:
+            for match in matches:
+                try:
+                    return json.loads(match.strip())
+                except json.JSONDecodeError:
+                    continue
+
+        # Strategy 4: Find balanced JSON object/array
+        start_obj = text.find("{")
+        start_arr = text.find("[")
+
+        if start_obj == -1 and start_arr == -1:
+            return None
+
+        if start_arr == -1 or (start_obj != -1 and start_obj < start_arr):
+            json_str = self._extract_balanced_braces(text[start_obj:], "{", "}")
+        else:
+            json_str = self._extract_balanced_braces(text[start_arr:], "[", "]")
+
+        if json_str:
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
+    def _extract_balanced_braces(self, text: str, open_char: str, close_char: str) -> Optional[str]:
+        """Extract balanced braces/brackets from text"""
+        if not text or text[0] != open_char:
+            return None
+
+        depth = 0
+        in_string = False
+        escape = False
+
+        for i, char in enumerate(text):
+            if escape:
+                escape = False
+                continue
+
+            if char == "\\":
+                escape = True
+                continue
+
+            if char == '"' and not in_string:
+                in_string = True
+            elif char == '"' and in_string:
+                in_string = False
+
+            if not in_string:
+                if char == open_char:
+                    depth += 1
+                elif char == close_char:
+                    depth -= 1
+                    if depth == 0:
+                        return text[:i+1]
+
+        return None
+
+    def close(self):
+        """Close the HTTP session"""
+        self.session.close()


### PR DESCRIPTION
Adds Requesty as an LLM/embedding provider alongside the existing OpenRouter and Ollama integrations.

Requesty (https://router.requesty.ai/v1) is an OpenAI-compatible router, so the integration mirrors the existing OpenRouter provider:
- New `RequestyClient` / `RequestyClientManager` in `server/integrations/requesty.py` (async httpx client, `Bearer REQUESTY_API_KEY` auth, same `provider/model` naming e.g. `openai/gpt-4.1-mini`, same JSON-extraction helpers). `verify_api_key` uses the OpenAI-compatible `/models` endpoint.
- Registered in `integrations/__init__.py` exports, `config/settings.py` (`LLM_PROVIDER=requesty`, `REQUESTY_BASE_URL`, default https://router.requesty.ai/v1), and the `http_server` client-manager factory + `/api/auth/register` validation branch.
- Added a synchronous skill util (`SKILL/simplemem-skill/src/utils/requesty.py`) and `references/requesty-guide.md` mirroring the OpenRouter skill files.
- Documented in `.env.example`, README, and the skill READMEs.
- Changes are applied to both the top-level `MCP/` + `SKILL/` trees and their `simplemem/integrations/` mirrors to keep them in sync.

Set `LLM_PROVIDER=requesty` and register with a Requesty API key (https://app.requesty.ai/api-keys) to use it. Docs: https://docs.requesty.ai

Verification:
- `py_compile` passes on all new/edited Python files.
- Live test against https://router.requesty.ai/v1 through the new `RequestyClient`: `verify_api_key()` returned True, and `chat_completion(openai/gpt-4o-mini)` returned "ok".

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
