### PR TITLE
refactor: extract vector store backend interface

### DIFF
--- a/simplemem/core/database/__init__.py
+++ b/simplemem/core/database/__init__.py
@@ -1,3 +1,17 @@
 from simplemem.core.database.vector_store import VectorStore
+from simplemem.core.database.vector_store_backend import (
+    LanceDBVectorStoreBackend,
+    ScoreOrder,
+    VectorStoreBackend,
+    VectorStoreRecord,
+    VectorStoreSearchResult,
+)
 
-__all__ = ["VectorStore"]
+__all__ = [
+    "LanceDBVectorStoreBackend",
+    "ScoreOrder",
+    "VectorStore",
+    "VectorStoreBackend",
+    "VectorStoreRecord",
+    "VectorStoreSearchResult",
+]

--- a/simplemem/core/database/vector_store.py
+++ b/simplemem/core/database/vector_store.py
@@ -1,185 +1,114 @@
-"""
-Vector Store - Multi-View Indexing (Section 3.1)
+"""Provider-neutral facade for SimpleMem's three retrieval paths."""
 
-Implements three-layer indexing I(m_k):
-- Semantic Layer: s_k = E_dense(m_k) - Dense vector similarity
-- Lexical Layer: l_k = E_sparse(m_k) - BM25 keyword matching (Tantivy FTS)
-- Symbolic Layer: r_k = E_sym(m_k) - Metadata filtering (SQL)
-"""
-from typing import List, Optional, Dict, Any
-import lancedb
-import pyarrow as pa
+from typing import Any, Callable, Dict, List, Optional
+
+from simplemem.core.database.vector_store_backend import (
+    LanceDBVectorStoreBackend,
+    VectorStoreBackend,
+    VectorStoreRecord,
+    VectorStoreSearchResult,
+)
 from simplemem.core.models.memory_entry import MemoryEntry
-from simplemem.core.utils.embedding import EmbeddingModel
 from simplemem.core.settings import settings as config
-import os
+from simplemem.core.utils.embedding import EmbeddingModel
+
+
+BackendFactory = Callable[[int], VectorStoreBackend]
 
 
 class VectorStore:
-    """
-    Multi-View Indexing - Storage and retrieval for memory units (Section 3.1)
-
-    Three-layer indexing I(m_k):
-    1. Semantic Layer: Dense embeddings for conceptual similarity
-    2. Lexical Layer: Tantivy FTS for exact keyword matching
-    3. Symbolic Layer: SQL-based metadata filtering
-    """
+    """Coordinate embeddings with a pluggable multi-view storage backend."""
 
     def __init__(
         self,
         db_path: str = None,
         embedding_model: EmbeddingModel = None,
         table_name: str = None,
-        storage_options: Optional[Dict[str, Any]] = None
+        storage_options: Optional[Dict[str, Any]] = None,
+        backend_factory: Optional[BackendFactory] = None,
     ):
         self.db_path = db_path or config.LANCEDB_PATH
         self.embedding_model = embedding_model or EmbeddingModel()
         self.table_name = table_name or config.MEMORY_TABLE_NAME
-        self.table = None
-        self._fts_initialized = False
+        self.storage_options = storage_options
 
-        # Detect if using cloud storage (GCS, S3, Azure)
-        self._is_cloud_storage = self.db_path.startswith(("gs://", "s3://", "az://"))
-
-        # Connect to database
-        if self._is_cloud_storage:
-            self.db = lancedb.connect(self.db_path, storage_options=storage_options)
+        if backend_factory is None:
+            self.backend = LanceDBVectorStoreBackend(
+                db_path=self.db_path,
+                table_name=self.table_name,
+                vector_dimension=self.embedding_model.dimension,
+                storage_options=self.storage_options,
+            )
         else:
-            os.makedirs(self.db_path, exist_ok=True)
-            self.db = lancedb.connect(self.db_path)
+            self.backend = backend_factory(self.embedding_model.dimension)
 
-        self._init_table()
+    @property
+    def db(self) -> Any:
+        """Expose the default backend's database handle for compatibility."""
+        return getattr(self.backend, "db", None)
 
-    def _init_table(self):
-        """Initialize table schema and FTS index."""
-        schema = pa.schema([
-            pa.field("entry_id", pa.string()),
-            pa.field("lossless_restatement", pa.string()),
-            pa.field("keywords", pa.list_(pa.string())),
-            pa.field("timestamp", pa.string()),
-            pa.field("location", pa.string()),
-            pa.field("persons", pa.list_(pa.string())),
-            pa.field("entities", pa.list_(pa.string())),
-            pa.field("topic", pa.string()),
-            pa.field("vector", pa.list_(pa.float32(), self.embedding_model.dimension))
-        ])
+    @property
+    def table(self) -> Any:
+        """Expose the default backend's table handle for compatibility."""
+        return getattr(self.backend, "table", None)
 
-        if self.table_name not in self.db.table_names():
-            self.table = self.db.create_table(self.table_name, schema=schema)
-            print(f"Created new table: {self.table_name}")
-        else:
-            self.table = self.db.open_table(self.table_name)
-            print(f"Opened existing table: {self.table_name}")
-
-    def _init_fts_index(self):
-        """Initialize Full-Text Search index on lossless_restatement column."""
-        if self._fts_initialized:
-            return
-
-        try:
-            if self._is_cloud_storage:
-                # Use native FTS for cloud storage (Tantivy only works with local filesystem)
-                self.table.create_fts_index(
-                    "lossless_restatement",
-                    use_tantivy=False,
-                    replace=True
-                )
-                print("FTS index created (native mode for cloud storage)")
-            else:
-                # Use Tantivy FTS for local storage (better performance)
-                self.table.create_fts_index(
-                    "lossless_restatement",
-                    use_tantivy=True,
-                    tokenizer_name="en_stem",
-                    replace=True
-                )
-                print("FTS index created (Tantivy mode)")
-            self._fts_initialized = True
-        except Exception as e:
-            print(f"FTS index creation skipped: {e}")
-
-    def _results_to_entries(self, results: List[dict]) -> List[MemoryEntry]:
-        """Convert LanceDB results to MemoryEntry objects."""
-        entries = []
-        for r in results:
-            try:
-                entries.append(MemoryEntry(
-                    entry_id=r["entry_id"],
-                    lossless_restatement=r["lossless_restatement"],
-                    keywords=list(r.get("keywords") or []),
-                    timestamp=r.get("timestamp") or None,
-                    location=r.get("location") or None,
-                    persons=list(r.get("persons") or []),
-                    entities=list(r.get("entities") or []),
-                    topic=r.get("topic") or None
-                ))
-            except Exception as e:
-                print(f"Warning: Failed to parse result: {e}")
-                continue
-        return entries
-
-    def add_entries(self, entries: List[MemoryEntry]):
-        """Batch add memory entries."""
+    def add_entries(self, entries: List[MemoryEntry]) -> None:
+        """Embed and insert a batch of memory entries."""
         if not entries:
             return
 
         restatements = [entry.lossless_restatement for entry in entries]
         vectors = self.embedding_model.encode_documents(restatements)
+        records = [
+            VectorStoreRecord(
+                entry_id=entry.entry_id,
+                vector=vector.tolist(),
+                metadata={
+                    "lossless_restatement": entry.lossless_restatement,
+                    "keywords": entry.keywords,
+                    "timestamp": entry.timestamp or "",
+                    "location": entry.location or "",
+                    "persons": entry.persons,
+                    "entities": entry.entities,
+                    "topic": entry.topic or "",
+                },
+            )
+            for entry, vector in zip(entries, vectors)
+        ]
 
-        data = []
-        for entry, vector in zip(entries, vectors):
-            data.append({
-                "entry_id": entry.entry_id,
-                "lossless_restatement": entry.lossless_restatement,
-                "keywords": entry.keywords,
-                "timestamp": entry.timestamp or "",
-                "location": entry.location or "",
-                "persons": entry.persons,
-                "entities": entry.entities,
-                "topic": entry.topic or "",
-                "vector": vector.tolist()
-            })
-
-        self.table.add(data)
+        self.backend.insert(records)
         print(f"Added {len(entries)} memory entries")
 
-        # Initialize FTS index after first data insertion
-        if not self._fts_initialized:
-            self._init_fts_index()
-
     def semantic_search(self, query: str, top_k: int = 5) -> List[MemoryEntry]:
-        """
-        Semantic Layer Search - Dense vector similarity (Section 3.1)
-        s_k = E_dense(m_k)
-        """
+        """Search the semantic retrieval path."""
         try:
-            if self.table.count_rows() == 0:
+            if self.backend.count() == 0:
                 return []
 
             query_vector = self.embedding_model.encode_single(query, is_query=True)
-            results = self.table.search(query_vector.tolist()).limit(top_k).to_list()
+            results = self.backend.semantic_search(
+                query_vector.tolist(),
+                top_k=top_k,
+            )
             return self._results_to_entries(results)
-
-        except Exception as e:
-            print(f"Error during semantic search: {e}")
+        except Exception as error:
+            print(f"Error during semantic search: {error}")
             return []
 
-    def keyword_search(self, keywords: List[str], top_k: int = 3) -> List[MemoryEntry]:
-        """
-        Lexical Layer Search - BM25 keyword matching (Section 3.1)
-        l_k = E_sparse(m_k)
-        """
+    def keyword_search(
+        self,
+        keywords: List[str],
+        top_k: int = 3,
+    ) -> List[MemoryEntry]:
+        """Search the lexical full-text retrieval path."""
         try:
-            if not keywords or self.table.count_rows() == 0:
+            if not keywords or self.backend.count() == 0:
                 return []
-
-            # LanceDB auto-detects string input as FTS query when FTS index exists
-            query = " ".join(keywords)
-            results = self.table.search(query).limit(top_k).to_list()
-            return self._results_to_entries(results)
-
-        except Exception as e:
-            print(f"Error during keyword search: {e}")
+            return self._results_to_entries(
+                self.backend.keyword_search(keywords, top_k=top_k)
+            )
+        except Exception as error:
+            print(f"Error during keyword search: {error}")
             return []
 
     def structured_search(
@@ -188,65 +117,62 @@ class VectorStore:
         timestamp_range: Optional[tuple] = None,
         location: Optional[str] = None,
         entities: Optional[List[str]] = None,
-        top_k: Optional[int] = None
+        top_k: Optional[int] = None,
     ) -> List[MemoryEntry]:
-        """
-        Symbolic Layer Search - Metadata filtering (Section 3.1)
-        r_k = E_sym(m_k), filters by timestamps, entities, persons
-        """
+        """Search the structured metadata retrieval path."""
         try:
-            if self.table.count_rows() == 0:
+            if self.backend.count() == 0:
                 return []
-
             if not any([persons, timestamp_range, location, entities]):
                 return []
 
-            conditions = []
-
-            if persons:
-                values = ", ".join(["'" + str(p).replace("'", "''") + "'" for p in persons])
-                conditions.append(f"array_has_any(persons, make_array({values}))")
-
-            if location:
-                safe_location = location.replace("'", "''")
-                conditions.append(f"location LIKE '%{safe_location}%'")
-
-            if entities:
-                values = ", ".join(["'" + str(e).replace("'", "''") + "'" for e in entities])
-                conditions.append(f"array_has_any(entities, make_array({values}))")
-
-            if timestamp_range:
-                start_time, end_time = timestamp_range
-                start_time = str(start_time).replace("'", "''")
-                end_time = str(end_time).replace("'", "''")
-                conditions.append(f"timestamp >= '{start_time}' AND timestamp <= '{end_time}'")
-
-            where_clause = " AND ".join(conditions)
-            query = self.table.search().where(where_clause, prefilter=True)
-
-            if top_k:
-                query = query.limit(top_k)
-
-            results = query.to_list()
-            return self._results_to_entries(results)
-
-        except Exception as e:
-            print(f"Error during structured search: {e}")
+            return self._results_to_entries(
+                self.backend.structured_search(
+                    persons=persons,
+                    timestamp_range=timestamp_range,
+                    location=location,
+                    entities=entities,
+                    top_k=top_k,
+                )
+            )
+        except Exception as error:
+            print(f"Error during structured search: {error}")
             return []
 
     def get_all_entries(self) -> List[MemoryEntry]:
         """Get all memory entries."""
-        results = self.table.to_arrow().to_pylist()
-        return self._results_to_entries(results)
+        return self._results_to_entries(self.backend.get_all())
 
-    def optimize(self):
-        """Optimize table after bulk insertions for better query performance."""
-        self.table.optimize()
+    def optimize(self) -> None:
+        """Optimize backend indexes after bulk insertions."""
+        self.backend.optimize()
         print("Table optimized")
 
-    def clear(self):
-        """Clear all data and reinitialize table."""
-        self.db.drop_table(self.table_name)
-        self._fts_initialized = False
-        self._init_table()
+    def clear(self) -> None:
+        """Clear all backend data."""
+        self.backend.clear()
         print("Database cleared")
+
+    @staticmethod
+    def _results_to_entries(
+        results: List[VectorStoreSearchResult],
+    ) -> List[MemoryEntry]:
+        entries = []
+        for result in results:
+            try:
+                metadata = result.metadata
+                entries.append(
+                    MemoryEntry(
+                        entry_id=result.entry_id,
+                        lossless_restatement=metadata["lossless_restatement"],
+                        keywords=list(metadata.get("keywords") or []),
+                        timestamp=metadata.get("timestamp") or None,
+                        location=metadata.get("location") or None,
+                        persons=list(metadata.get("persons") or []),
+                        entities=list(metadata.get("entities") or []),
+                        topic=metadata.get("topic") or None,
+                    )
+                )
+            except Exception as error:
+                print(f"Warning: Failed to parse result: {error}")
+        return entries

--- a/simplemem/core/database/vector_store_backend.py
+++ b/simplemem/core/database/vector_store_backend.py
@@ -1,0 +1,323 @@
+"""Vector store backend contracts and the default LanceDB implementation."""
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+import re
+from typing import Any, Dict, List, Optional, Protocol, Sequence
+
+import lancedb
+import pyarrow as pa
+
+
+class ScoreOrder(str, Enum):
+    """Ordering semantics for scores returned by a retrieval path."""
+
+    ASCENDING = "ascending"
+    DESCENDING = "descending"
+
+
+@dataclass(frozen=True)
+class VectorStoreRecord:
+    """A vector and its backend-neutral memory metadata."""
+
+    entry_id: str
+    vector: Sequence[float]
+    metadata: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class VectorStoreSearchResult:
+    """A backend-neutral retrieval result."""
+
+    entry_id: str
+    metadata: Dict[str, Any]
+    score: Optional[float] = None
+
+
+class VectorStoreBackend(Protocol):
+    """Storage contract for semantic, lexical, and structured retrieval."""
+
+    semantic_score_order: ScoreOrder
+    keyword_score_order: ScoreOrder
+
+    def insert(self, records: Sequence[VectorStoreRecord]) -> None:
+        """Insert memory records and their dense vectors."""
+        ...
+
+    def semantic_search(
+        self,
+        query_vector: Sequence[float],
+        top_k: int,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorStoreSearchResult]:
+        """Return dense-vector results ranked from best to worst."""
+        ...
+
+    def keyword_search(
+        self,
+        keywords: Sequence[str],
+        top_k: int,
+    ) -> List[VectorStoreSearchResult]:
+        """Return full-text results ranked from best to worst."""
+        ...
+
+    def structured_search(
+        self,
+        persons: Optional[Sequence[str]] = None,
+        timestamp_range: Optional[tuple] = None,
+        location: Optional[str] = None,
+        entities: Optional[Sequence[str]] = None,
+        top_k: Optional[int] = None,
+    ) -> List[VectorStoreSearchResult]:
+        """Return records matching structured metadata constraints."""
+        ...
+
+    def count(self) -> int:
+        """Return the number of stored records."""
+        ...
+
+    def get_all(self) -> List[VectorStoreSearchResult]:
+        """Return every stored record."""
+        ...
+
+    def optimize(self) -> None:
+        """Optimize backend indexes after bulk insertion."""
+        ...
+
+    def clear(self) -> None:
+        """Remove all stored records and recreate backend state."""
+        ...
+
+
+class LanceDBVectorStoreBackend:
+    """Default vector store backend using LanceDB and Tantivy."""
+
+    semantic_score_order = ScoreOrder.ASCENDING
+    keyword_score_order = ScoreOrder.DESCENDING
+    _field_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def __init__(
+        self,
+        db_path: str,
+        table_name: str,
+        vector_dimension: int,
+        storage_options: Optional[Dict[str, Any]] = None,
+    ):
+        self.db_path = db_path
+        self.table_name = table_name
+        self.vector_dimension = vector_dimension
+        self._fts_initialized = False
+        self._is_cloud_storage = self.db_path.startswith(("gs://", "s3://", "az://"))
+
+        if self._is_cloud_storage:
+            self.db = lancedb.connect(
+                self.db_path,
+                storage_options=storage_options,
+            )
+        else:
+            os.makedirs(self.db_path, exist_ok=True)
+            self.db = lancedb.connect(self.db_path)
+
+        self._init_table()
+
+    def _init_table(self) -> None:
+        schema = pa.schema(
+            [
+                pa.field("entry_id", pa.string()),
+                pa.field("lossless_restatement", pa.string()),
+                pa.field("keywords", pa.list_(pa.string())),
+                pa.field("timestamp", pa.string()),
+                pa.field("location", pa.string()),
+                pa.field("persons", pa.list_(pa.string())),
+                pa.field("entities", pa.list_(pa.string())),
+                pa.field("topic", pa.string()),
+                pa.field(
+                    "vector",
+                    pa.list_(pa.float32(), self.vector_dimension),
+                ),
+            ]
+        )
+
+        if self.table_name not in self.db.table_names():
+            self.table = self.db.create_table(self.table_name, schema=schema)
+            print(f"Created new table: {self.table_name}")
+        else:
+            self.table = self.db.open_table(self.table_name)
+            print(f"Opened existing table: {self.table_name}")
+
+    def _init_fts_index(self) -> None:
+        if self._fts_initialized:
+            return
+
+        try:
+            if self._is_cloud_storage:
+                self.table.create_fts_index(
+                    "lossless_restatement",
+                    use_tantivy=False,
+                    replace=True,
+                )
+                print("FTS index created (native mode for cloud storage)")
+            else:
+                self.table.create_fts_index(
+                    "lossless_restatement",
+                    use_tantivy=True,
+                    tokenizer_name="en_stem",
+                    replace=True,
+                )
+                print("FTS index created (Tantivy mode)")
+            self._fts_initialized = True
+        except Exception as error:
+            print(f"FTS index creation skipped: {error}")
+
+    def insert(self, records: Sequence[VectorStoreRecord]) -> None:
+        if not records:
+            return
+
+        rows = [
+            {
+                "entry_id": record.entry_id,
+                **record.metadata,
+                "vector": list(record.vector),
+            }
+            for record in records
+        ]
+        self.table.add(rows)
+        self._init_fts_index()
+
+    def semantic_search(
+        self,
+        query_vector: Sequence[float],
+        top_k: int,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorStoreSearchResult]:
+        if self.count() == 0:
+            return []
+
+        query = self.table.search(list(query_vector))
+        if filters:
+            query = query.where(self._build_filter_expression(filters), prefilter=True)
+
+        results = self._rows_to_results(
+            query.limit(top_k).to_list(),
+            score_field="_distance",
+        )
+        results.sort(key=lambda result: result.score)
+        return results
+
+    def keyword_search(
+        self,
+        keywords: Sequence[str],
+        top_k: int,
+    ) -> List[VectorStoreSearchResult]:
+        if not keywords or self.count() == 0:
+            return []
+
+        query = " ".join(keywords)
+        results = self._rows_to_results(
+            self.table.search(query).limit(top_k).to_list(),
+            score_field="_score",
+        )
+        results.sort(key=lambda result: result.score, reverse=True)
+        return results
+
+    def structured_search(
+        self,
+        persons: Optional[Sequence[str]] = None,
+        timestamp_range: Optional[tuple] = None,
+        location: Optional[str] = None,
+        entities: Optional[Sequence[str]] = None,
+        top_k: Optional[int] = None,
+    ) -> List[VectorStoreSearchResult]:
+        if self.count() == 0:
+            return []
+        if not any([persons, timestamp_range, location, entities]):
+            return []
+
+        conditions = []
+        if persons:
+            values = ", ".join(self._quote(value) for value in persons)
+            conditions.append(f"array_has_any(persons, make_array({values}))")
+        if location:
+            conditions.append(f"location LIKE '%{self._escape(location)}%'")
+        if entities:
+            values = ", ".join(self._quote(value) for value in entities)
+            conditions.append(f"array_has_any(entities, make_array({values}))")
+        if timestamp_range:
+            start_time, end_time = timestamp_range
+            conditions.append(
+                f"timestamp >= {self._quote(start_time)} "
+                f"AND timestamp <= {self._quote(end_time)}"
+            )
+
+        query = self.table.search().where(" AND ".join(conditions), prefilter=True)
+        if top_k:
+            query = query.limit(top_k)
+        return self._rows_to_results(query.to_list())
+
+    def count(self) -> int:
+        return self.table.count_rows()
+
+    def get_all(self) -> List[VectorStoreSearchResult]:
+        return self._rows_to_results(self.table.to_arrow().to_pylist())
+
+    def optimize(self) -> None:
+        self.table.optimize()
+
+    def clear(self) -> None:
+        self.db.drop_table(self.table_name)
+        self._fts_initialized = False
+        self._init_table()
+
+    @classmethod
+    def _build_filter_expression(cls, filters: Dict[str, Any]) -> str:
+        conditions = []
+        for field, value in filters.items():
+            if not cls._field_pattern.fullmatch(field):
+                raise ValueError(f"Invalid semantic filter field: {field!r}")
+            conditions.append(f"{field} = {cls._format_filter_value(value)}")
+        return " AND ".join(conditions)
+
+    @classmethod
+    def _format_filter_value(cls, value: Any) -> str:
+        if isinstance(value, bool):
+            return "TRUE" if value else "FALSE"
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, str):
+            return cls._quote(value)
+        raise TypeError(
+            "Semantic filters support only string, boolean, integer, and float values"
+        )
+
+    @classmethod
+    def _quote(cls, value: Any) -> str:
+        return "'" + cls._escape(value) + "'"
+
+    @staticmethod
+    def _escape(value: Any) -> str:
+        return str(value).replace("'", "''")
+
+    @staticmethod
+    def _rows_to_results(
+        rows: Sequence[Dict[str, Any]],
+        score_field: Optional[str] = None,
+    ) -> List[VectorStoreSearchResult]:
+        results = []
+        for row in rows:
+            metadata = {
+                key: value
+                for key, value in row.items()
+                if key not in {"entry_id", "vector", "_distance", "_score"}
+            }
+            score = None
+            if score_field is not None and row.get(score_field) is not None:
+                score = float(row[score_field])
+            results.append(
+                VectorStoreSearchResult(
+                    entry_id=row["entry_id"],
+                    metadata=metadata,
+                    score=score,
+                )
+            )
+        return results

--- a/tests/test_vector_store_backend.py
+++ b/tests/test_vector_store_backend.py
@@ -1,0 +1,398 @@
+import json
+
+import numpy as np
+import pytest
+
+from simplemem.core.database import (
+    LanceDBVectorStoreBackend,
+    ScoreOrder,
+    VectorStore,
+    VectorStoreSearchResult,
+)
+from simplemem.core.hybrid_retriever import HybridRetriever
+from simplemem.core.models.memory_entry import MemoryEntry
+
+
+class DeterministicEmbedder:
+    dimension = 3
+
+    def encode_documents(self, texts):
+        return np.stack([self._encode(text) for text in texts])
+
+    def encode_single(self, text, is_query=False):
+        return self._encode(text)
+
+    @staticmethod
+    def _encode(text):
+        text = text.lower()
+        if "coffee" in text or "espresso" in text:
+            vector = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        elif "apollo" in text or "budget" in text:
+            vector = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        else:
+            vector = np.array([-1.0, 0.0, 0.0], dtype=np.float32)
+        return vector
+
+
+class DeterministicLLM:
+    def chat_completion(self, messages, **kwargs):
+        prompt = messages[-1]["content"]
+        if "extract key information" in prompt:
+            return json.dumps(
+                {
+                    "keywords": ["Apollo"],
+                    "persons": ["Carol"],
+                    "time_expression": None,
+                    "location": None,
+                    "entities": [],
+                }
+            )
+        if "information requirements analysis" in prompt:
+            return json.dumps(
+                {
+                    "reasoning": "Use one semantic query.",
+                    "queries": ["coffee status"],
+                }
+            )
+        if "determine what specific information is required" in prompt:
+            return json.dumps(
+                {
+                    "question_type": "factual",
+                    "key_entities": ["coffee", "Apollo", "Carol"],
+                    "required_info": [
+                        {
+                            "info_type": "facts",
+                            "description": "Retrieve all three facts",
+                            "priority": "high",
+                        }
+                    ],
+                    "relationships": [],
+                    "minimal_queries_needed": 1,
+                }
+            )
+        raise AssertionError(f"Unexpected LLM prompt: {prompt[:120]}")
+
+    @staticmethod
+    def extract_json(response):
+        return json.loads(response)
+
+
+class InMemoryVectorStoreBackend:
+    semantic_score_order = ScoreOrder.ASCENDING
+    keyword_score_order = ScoreOrder.DESCENDING
+
+    def __init__(self):
+        self.records = []
+        self.optimized = False
+
+    def insert(self, records):
+        self.records.extend(records)
+
+    def semantic_search(self, query_vector, top_k, filters=None):
+        records = self.records
+        if filters:
+            records = [
+                record
+                for record in records
+                if all(
+                    record.metadata.get(key) == value for key, value in filters.items()
+                )
+            ]
+        ranked = sorted(
+            records,
+            key=lambda record: sum(
+                (left - right) ** 2 for left, right in zip(record.vector, query_vector)
+            ),
+        )
+        return [
+            self._result(
+                record,
+                score=sum(
+                    (left - right) ** 2
+                    for left, right in zip(record.vector, query_vector)
+                ),
+            )
+            for record in ranked[:top_k]
+        ]
+
+    def keyword_search(self, keywords, top_k):
+        lowered_keywords = [keyword.lower() for keyword in keywords]
+
+        def keyword_score(record):
+            text = " ".join(
+                [
+                    record.metadata["lossless_restatement"],
+                    *record.metadata["keywords"],
+                ]
+            ).lower()
+            return sum(text.count(keyword) for keyword in lowered_keywords)
+
+        ranked = [
+            (record, keyword_score(record))
+            for record in self.records
+            if keyword_score(record) > 0
+        ]
+        ranked.sort(key=lambda item: item[1], reverse=True)
+        return [self._result(record, score=score) for record, score in ranked[:top_k]]
+
+    def structured_search(
+        self,
+        persons=None,
+        timestamp_range=None,
+        location=None,
+        entities=None,
+        top_k=None,
+    ):
+        matches = []
+        for record in self.records:
+            metadata = record.metadata
+            if persons and not set(persons).intersection(metadata["persons"]):
+                continue
+            if location and location not in metadata["location"]:
+                continue
+            if entities and not set(entities).intersection(metadata["entities"]):
+                continue
+            if timestamp_range:
+                start_time, end_time = timestamp_range
+                if not start_time <= metadata["timestamp"] <= end_time:
+                    continue
+            matches.append(self._result(record))
+        return matches[:top_k] if top_k else matches
+
+    def count(self):
+        return len(self.records)
+
+    def get_all(self):
+        return [self._result(record) for record in self.records]
+
+    def optimize(self):
+        self.optimized = True
+
+    def clear(self):
+        self.records.clear()
+
+    @staticmethod
+    def _result(record, score=None):
+        return VectorStoreSearchResult(
+            entry_id=record.entry_id,
+            metadata=record.metadata,
+            score=score,
+        )
+
+
+class TrackingVectorStoreBackend:
+    def __init__(self, delegate):
+        self.delegate = delegate
+        self.semantic_score_order = delegate.semantic_score_order
+        self.keyword_score_order = delegate.keyword_score_order
+        self.calls = {
+            "insert": 0,
+            "semantic_search": 0,
+            "keyword_search": 0,
+            "structured_search": 0,
+            "get_all": 0,
+            "optimize": 0,
+            "clear": 0,
+        }
+        self.last_records = []
+
+    def insert(self, records):
+        self.calls["insert"] += 1
+        self.last_records = list(records)
+        self.delegate.insert(records)
+
+    def semantic_search(self, query_vector, top_k, filters=None):
+        self.calls["semantic_search"] += 1
+        return self.delegate.semantic_search(query_vector, top_k, filters)
+
+    def keyword_search(self, keywords, top_k):
+        self.calls["keyword_search"] += 1
+        return self.delegate.keyword_search(keywords, top_k)
+
+    def structured_search(self, **kwargs):
+        self.calls["structured_search"] += 1
+        return self.delegate.structured_search(**kwargs)
+
+    def count(self):
+        return self.delegate.count()
+
+    def get_all(self):
+        self.calls["get_all"] += 1
+        return self.delegate.get_all()
+
+    def optimize(self):
+        self.calls["optimize"] += 1
+        self.delegate.optimize()
+
+    def clear(self):
+        self.calls["clear"] += 1
+        self.delegate.clear()
+
+
+@pytest.fixture
+def entries():
+    return [
+        MemoryEntry(
+            entry_id="coffee",
+            lossless_restatement="Alice drinks espresso at the neighborhood cafe.",
+            keywords=["coffee", "espresso"],
+            persons=["Alice"],
+            topic="coffee",
+        ),
+        MemoryEntry(
+            entry_id="apollo",
+            lossless_restatement="The Project Apollo budget was approved.",
+            keywords=["Apollo", "budget"],
+            persons=["Bob"],
+            topic="finance",
+        ),
+        MemoryEntry(
+            entry_id="carol",
+            lossless_restatement="Carol planned a trip to Paris.",
+            keywords=["travel", "Paris"],
+            persons=["Carol"],
+            location="Paris",
+            topic="travel",
+        ),
+    ]
+
+
+@pytest.fixture
+def lancedb_store(tmp_path, entries):
+    store = VectorStore(
+        db_path=str(tmp_path / "lancedb"),
+        table_name="entries",
+        embedding_model=DeterministicEmbedder(),
+    )
+    store.add_entries(entries)
+    return store
+
+
+@pytest.fixture
+def custom_store(tmp_path, entries):
+    created = []
+    unused_default_path = tmp_path / "unused-lancedb"
+
+    def factory(vector_dimension):
+        assert vector_dimension == DeterministicEmbedder.dimension
+        backend = TrackingVectorStoreBackend(InMemoryVectorStoreBackend())
+        created.append(backend)
+        return backend
+
+    store = VectorStore(
+        db_path=str(unused_default_path),
+        table_name="entries",
+        embedding_model=DeterministicEmbedder(),
+        backend_factory=factory,
+    )
+    store.add_entries(entries)
+
+    assert not unused_default_path.exists()
+    assert store.backend is created[0]
+    return store
+
+
+def test_lancedb_backend_preserves_semantic_and_keyword_score_order(lancedb_store):
+    backend = lancedb_store.backend
+    assert isinstance(backend, LanceDBVectorStoreBackend)
+
+    semantic_results = backend.semantic_search([1.0, 0.0, 0.0], top_k=3)
+    keyword_results = backend.keyword_search(["Apollo"], top_k=3)
+
+    assert backend.semantic_score_order == ScoreOrder.ASCENDING
+    assert backend.keyword_score_order == ScoreOrder.DESCENDING
+    assert [result.entry_id for result in semantic_results] == [
+        "coffee",
+        "apollo",
+        "carol",
+    ]
+    assert [result.score for result in semantic_results] == sorted(
+        result.score for result in semantic_results
+    )
+    assert [result.entry_id for result in keyword_results] == ["apollo"]
+    assert keyword_results[0].score is not None
+
+
+def test_custom_backend_owns_all_three_retrieval_paths(custom_store):
+    assert (
+        custom_store.semantic_search("coffee status", top_k=1)[0].entry_id == "coffee"
+    )
+    assert custom_store.keyword_search(["Apollo"], top_k=1)[0].entry_id == "apollo"
+    assert (
+        custom_store.structured_search(persons=["Carol"], top_k=1)[0].entry_id
+        == "carol"
+    )
+
+    assert custom_store.backend.calls["insert"] == 1
+    assert custom_store.backend.calls["semantic_search"] == 1
+    assert custom_store.backend.calls["keyword_search"] == 1
+    assert custom_store.backend.calls["structured_search"] == 1
+    assert custom_store.backend.last_records[1].metadata["topic"] == "finance"
+
+
+def test_lancedb_backend_applies_scalar_semantic_filters(lancedb_store):
+    results = lancedb_store.backend.semantic_search(
+        [1.0, 0.0, 0.0],
+        top_k=3,
+        filters={"topic": "finance"},
+    )
+
+    assert [result.entry_id for result in results] == ["apollo"]
+
+
+def test_lancedb_backend_rejects_unsafe_filter_fields(lancedb_store):
+    with pytest.raises(ValueError, match="Invalid semantic filter field"):
+        lancedb_store.backend.semantic_search(
+            [1.0, 0.0, 0.0],
+            top_k=3,
+            filters={"topic OR TRUE": "finance"},
+        )
+
+
+def test_lancedb_backend_escapes_filter_values(lancedb_store):
+    results = lancedb_store.backend.semantic_search(
+        [1.0, 0.0, 0.0],
+        top_k=3,
+        filters={"topic": "finance' OR TRUE"},
+    )
+
+    assert results == []
+
+
+def test_lancedb_backend_preserves_all_three_public_retrieval_paths(lancedb_store):
+    assert (
+        lancedb_store.semantic_search("coffee status", top_k=1)[0].entry_id == "coffee"
+    )
+    assert lancedb_store.keyword_search(["Apollo"], top_k=1)[0].entry_id == "apollo"
+    assert (
+        lancedb_store.structured_search(persons=["Carol"], top_k=1)[0].entry_id
+        == "carol"
+    )
+
+
+def test_custom_backend_owns_lifecycle_operations(custom_store):
+    assert len(custom_store.get_all_entries()) == 3
+    custom_store.optimize()
+    custom_store.clear()
+
+    assert custom_store.backend.calls["get_all"] == 1
+    assert custom_store.backend.calls["optimize"] == 1
+    assert custom_store.backend.calls["clear"] == 1
+    assert custom_store.get_all_entries() == []
+
+
+def test_hybrid_retrieval_uses_custom_backend_for_all_paths(custom_store):
+    retriever = HybridRetriever(
+        llm_client=DeterministicLLM(),
+        vector_store=custom_store,
+        semantic_top_k=1,
+        keyword_top_k=1,
+        structured_top_k=1,
+        enable_planning=True,
+        enable_reflection=False,
+        enable_parallel_retrieval=False,
+    )
+
+    results = retriever.retrieve("coffee Apollo Carol")
+
+    assert [entry.entry_id for entry in results] == ["coffee", "apollo", "carol"]


### PR DESCRIPTION
## Summary

- introduce a provider-neutral `VectorStoreBackend` contract covering insertion, semantic search, full-text search, structured filtering, counting, enumeration, optimization, and clearing
- move the existing LanceDB dense search, Tantivy/native FTS, and structured SQL filtering behavior into the default `LanceDBVectorStoreBackend`
- keep embedding generation in the `VectorStore` facade and let a backend factory receive the resolved vector dimension
- add focused contract tests with both the real LanceDB backend and a custom in-memory backend that owns all three retrieval paths

## Rationale

The earlier dense-only boundary still left keyword search, structured retrieval, and empty-store checks tied directly to LanceDB. A second provider would therefore have needed to dual-write every record into LanceDB, creating hidden coupling and synchronization risk. This broader boundary makes one backend responsible for the complete multi-view index while keeping SimpleMem's existing hybrid retrieval orchestration unchanged.

## Scope

This remains the abstraction-only first step discussed in #72. It adds no new storage provider, dependency, configuration key, or default behavior change. LanceDB and Tantivy remain the default implementation.

## Validation

- `python -m pytest tests/test_vector_store_backend.py -q` — 8 passed
- `ruff check` and `ruff format --check` on all changed Python files
- `python -m compileall -q simplemem/core/database tests/test_vector_store_backend.py`
- `python setup.py check`
- real end-to-end text-memory run using hosted embedding and completion APIs: three dialogues were built into memory, semantic/keyword/structured retrieval returned the expected contexts, and the final answer was `24 July 2026 at 2:00 PM at Starbucks`