### PR TITLE
fix(code_quality): Missing docstring on public function `add_dialogue` in simpl

### DIFF
--- a/simplemem_router.py
+++ b/simplemem_router.py
@@ -317,7 +317,18 @@ class AutoMemory:
     def add_dialogue(
         self, speaker: str, content: str, timestamp: Optional[str] = None
     ) -> Any:
-        """Add a dialogue turn.  *Selects text backend on first call.*"""
+        """Add a single dialogue turn to the text-mode memory system.
+
+        Automatically selects the text backend on the first call.
+
+        Args:
+            speaker: Name of the speaker.
+            content: Text content of the dialogue turn.
+            timestamp: Optional ISO 8601 timestamp for the dialogue turn.
+
+        Returns:
+            The result returned by the underlying text backend.
+        """
         self._require("text", "add_dialogue")
         return self._backend.add_dialogue(speaker, content, timestamp)
 


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `add_dialogue` in simplemem_router.py (aiming-lab/SimpleMem)

**Wedge type:** `code_quality`

**Issue:** https://github.com/aiming-lab/SimpleMem/blob/main/simplemem_router.py

## Changes

- `simplemem_router.py`

**Diff size:** 13 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>